### PR TITLE
Add decoding of Base64 before hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,5 @@ be on your way to contributing!
 
 ## Changelog
 
+* 2.0.0 - MD5, SHA1, and SHA256 Indicators for Base64 Content are now hashes of the decoded Base64 Content
 * 1.0.0 - Initial release

--- a/eml_parser/email_parser.py
+++ b/eml_parser/email_parser.py
@@ -13,6 +13,7 @@ from eml_parser.icon_file import IconFile
 from eml_parser.microsoft_newline_cleaner import remove_microsoft_newlines
 from eml_parser.indicators import Indicators
 
+
 class EmailParser(object):
     """
     Handles all the parsing for an email.

--- a/eml_parser/email_parser.py
+++ b/eml_parser/email_parser.py
@@ -13,7 +13,6 @@ from eml_parser.icon_file import IconFile
 from eml_parser.microsoft_newline_cleaner import remove_microsoft_newlines
 from eml_parser.indicators import Indicators
 
-
 class EmailParser(object):
     """
     Handles all the parsing for an email.
@@ -330,6 +329,7 @@ class EmailParser(object):
                 file_name=filename,
                 content_type=part.get_content_type(),
                 content=content,
+                content_transfer_encoding=content_transfer_encoding,
             )
 
             #################

--- a/eml_parser/icon_email.py
+++ b/eml_parser/icon_email.py
@@ -118,7 +118,7 @@ class IconEmail(object):
     # are used to remove duplicates in the flattened lists.
 
     def __eq__(self, other):
-        """ Check for equality """
+        """Check for equality"""
         return (
             self.id == other.id
             and self.subject == other.subject
@@ -131,7 +131,7 @@ class IconEmail(object):
         )
 
     def __hash__(self):
-        """ Return a unique hash """
+        """Return a unique hash"""
 
         # 'Tue, 13 Aug 2019 12:56:31 -0500'
         return hash(
@@ -156,5 +156,5 @@ class IconEmail(object):
         )
 
     def __lt__(self, other):
-        """ Less than, allows class to be sorted"""
+        """Less than, allows class to be sorted"""
         return self.subject < other.subject

--- a/eml_parser/icon_file.py
+++ b/eml_parser/icon_file.py
@@ -5,11 +5,11 @@ from eml_parser.indicators import Indicators
 
 
 class IconFile(object):
-    def __init__(self, file_name: str = "", content_type: str = "", content: str = ""):
+    def __init__(self, file_name: str = "", content_type: str = "", content: str = "", content_transfer_encoding: str = ""):
         self.name = file_name
         self.content = content
         self.content_type = content_type
-        self.indicators = Indicators(content)
+        self.indicators = Indicators(content, content_transfer_encoding)
 
     # May not need this
     def make_serializable(self) -> dict:

--- a/eml_parser/icon_file.py
+++ b/eml_parser/icon_file.py
@@ -5,7 +5,13 @@ from eml_parser.indicators import Indicators
 
 
 class IconFile(object):
-    def __init__(self, file_name: str = "", content_type: str = "", content: str = "", content_transfer_encoding: str = ""):
+    def __init__(
+        self,
+        file_name: str = "",
+        content_type: str = "",
+        content: str = "",
+        content_transfer_encoding: str = "",
+    ):
         self.name = file_name
         self.content = content
         self.content_type = content_type
@@ -42,5 +48,5 @@ class IconFile(object):
         )
 
     def __lt__(self, other):
-        """ Less than, allows class to be sorted"""
+        """Less than, allows class to be sorted"""
         return self.name < other.name

--- a/eml_parser/indicators.py
+++ b/eml_parser/indicators.py
@@ -1,12 +1,15 @@
 import hashlib
 import json
-
 import eml_parser.helper as helper
+import base64
 
 
 class Indicators(object):
-    def __init__(self, content: str):
-        encoded_content = content.encode("UTF-8")
+    def __init__(self, content: str, content_transfer_encoding: str = ""):
+        if content_transfer_encoding.lower() == "base64":
+            encoded_content = base64.b64decode(content)
+        else:
+            encoded_content = content.encode("UTF-8")
         self.md5 = hashlib.md5(encoded_content).hexdigest()
         self.sha1 = hashlib.sha1(encoded_content).hexdigest()
         self.sha256 = hashlib.sha256(encoded_content).hexdigest()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="python_eml_parser",
-    version="1.0.0",
+    version="2.0.0",
     description="Rapid7 InsightConnect email parser for email plugins",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/unit_test/payloads/API Security Survey (please take this important survey) .eml
+++ b/unit_test/payloads/API Security Survey (please take this important survey) .eml
@@ -23,9 +23,9 @@ Received: from example.com.example.com1.example.com (198.162.1.1) by
  Server (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384) id
  15.20.2032.15 via Frontend Transport; Thu, 18 Jul 2019 12:24:38 +0000
 DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.com; s=s2048; t=1563452678; bh=TGatgKz/i01tp8qC32NV2+NjMXzoITKGUQMjnShZ6Jg=; h=Date:From:To:Subject:References:From:Subject; b=PdoXuxcU9GOIwDRHNYn9FTRQCxvxaselOi67WJIeLz5y1ZXQWA80IvSQHeS0Ln12tn+fk17Aulmg30bBw+UlJlDGesGZWBowQS8XtkqeG8WQfEFKQPuwiuzvQWNfd8ELNSh97nhdip7K1cLvQ1XfIZI8lHtyDST7XaEzmXOolKBfxB34CAyUjlA/RvUchtsM34+pmikm3YHz6uCZOULfQXOA/kwME3QIeYzcPFgHvGy8MzWB6RDrQa3JOs94bbsoJE7xMLkXQZNHuBgiX5Ik+1BlDgEUcGjkT+gjcZBMY0BxzHQwdbNnw9KxkgkKvEcpRvcEsjcPvX+kvwaJLxrLUg==
-X-YMail-OSG: example.comexample.com.mbi_example.com5PbPXC4
+X-YMail-OSG: example.com.example.com_example.com5PbPXC4
  example.com10wg4xl6OsZNG5lWtzYhDOf_QQCEINV0oroD
- BM_example.comexample.com0vzRAzzjWtxuM_J_dKysDBdolm9UInzW30dRq.1ljpW
+ BM_example.com.com0vzRAzzjWtxuM_J_dKysDBdolm9UInzW30dRq.1ljpW
  n9A6XAdtgnZS9mVPhvo3NQT9jOGJcKjPUPEB9URV1itW6H1uAoZTzJOFoZkliMbdmz6xUIqVhkLY
  Kl_3PPkpHEa71bqNJYHUpxHLeXHjjyaSA4jDctSXpXAqud9CKSVL1qHoUUsXBf5KDLZ7htymnM_q
  example.com41qUwJmOOQQyd8jd0CuxyuJDoKojrlZzO0iMLT4g0shqkDA8DCe4.6Gof7P32vA5dJ
@@ -38,7 +38,7 @@ X-YMail-OSG: example.comexample.com.mbi_example.com5PbPXC4
  RPA2EaOCe9kbUef7VwylaJLCElHOgbym6RlcJMsqfM1FskouwwoOKMvgYsHGr7GhxwR.32z57SDg
  example.com_pxZyxFySmC8JU2Bhmuehjl6agnvOTwpphzbaDDuxpZgU
  5DK3ns8pIGu1yCIxzvR8qUXk9alLg2cix52mpW6_l5SMtuy98RjQXOrj3QKeUawnudjuyjOsfUF7
- 4UmqyLzY_.82JY379_jmlhcTrKgA.example.com.I9gw_D7UiIPbBonaPe3xkhszctH
+ 4UmqyLzY_.82JY379_example.com.com.I9gw_D7UiIPbBonaPe3xkhszctH
  VZp0Za4VmTduYpC__kGdrpwctXSGsw9qB60V8lWejFtP.3YikAF1L8rLWWu4rA2Whlff8dtq4DhL
  je6ToVRF2UTUE_mQ-
 Received: from example.com.example.com1.example.com by example.com.example.com1.example.com with HTTP; Thu, 18 Jul 2019 12:24:38 +0000

--- a/unit_test/payloads/get_attachment_email_payload.json
+++ b/unit_test/payloads/get_attachment_email_payload.json
@@ -25,7 +25,7 @@
                 "isReadReceiptRequested": false,
                 "isRead": true,
                 "isDraft": false,
-                "webLink": "https://example.comexample.com/owa/?AttachmentItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAAAAAEMAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE4BRpqAAABEgAQAIs8nFX%2B2wRHvWNkYLt8Lyo%3D&exvsurl=1&viewmodel=ItemAttachment",
+                "webLink": "https://example.com.com/owa/?AttachmentItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAAAAAEMAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE4BRpqAAABEgAQAIs8nFX%2B2wRHvWNkYLt8Lyo%3D&exvsurl=1&viewmodel=ItemAttachment",
                 "internetMessageHeaders": [
                     {
                         "name": "Received",

--- a/unit_test/payloads/get_attachment_email_with_attachment_payload.json
+++ b/unit_test/payloads/get_attachment_email_with_attachment_payload.json
@@ -25,7 +25,7 @@
                 "isReadReceiptRequested": false,
                 "isRead": true,
                 "isDraft": false,
-                "webLink": "https://example.comexample.com/owa/?AttachmentItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAAAAAEMAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE4BRpqAAABEgAQAIs8nFX%2B2wRHvWNkYLt8Lyo%3D&exvsurl=1&viewmodel=ItemAttachment",
+                "webLink": "https://example.com.com/owa/?AttachmentItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAAAAAEMAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE4BRpqAAABEgAQAIs8nFX%2B2wRHvWNkYLt8Lyo%3D&exvsurl=1&viewmodel=ItemAttachment",
                 "internetMessageHeaders": [
                     {
                         "name": "Received",

--- a/unit_test/payloads/get_messages_payload.json
+++ b/unit_test/payloads/get_messages_payload.json
@@ -22,7 +22,7 @@
             "isReadReceiptRequested": false,
             "isRead": false,
             "isDraft": false,
-            "webLink": "https://example.comexample.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcO0AAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
+            "webLink": "https://example.com.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcO0AAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
             "inferenceClassification": "focused",
             "body": {
                 "contentType": "html",
@@ -81,7 +81,7 @@
             "isReadReceiptRequested": false,
             "isRead": false,
             "isDraft": false,
-            "webLink": "https://example.comexample.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAAAAAEMAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dZaGAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
+            "webLink": "https://example.com.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAAAAAEMAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dZaGAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
             "inferenceClassification": "focused",
             "body": {
                 "contentType": "html",
@@ -134,7 +134,7 @@
             "isReadReceiptRequested": false,
             "isRead": false,
             "isDraft": false,
-            "webLink": "https://example.comexample.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOzAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
+            "webLink": "https://example.com.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOzAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
             "inferenceClassification": "focused",
             "body": {
                 "contentType": "html",
@@ -193,7 +193,7 @@
             "isReadReceiptRequested": false,
             "isRead": false,
             "isDraft": false,
-            "webLink": "https://example.comexample.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOyAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
+            "webLink": "https://example.com.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOyAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
             "inferenceClassification": "focused",
             "body": {
                 "contentType": "html",
@@ -252,7 +252,7 @@
             "isReadReceiptRequested": false,
             "isRead": false,
             "isDraft": false,
-            "webLink": "https://example.comexample.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOxAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
+            "webLink": "https://example.com.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOxAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
             "inferenceClassification": "focused",
             "body": {
                 "contentType": "html",
@@ -311,7 +311,7 @@
             "isReadReceiptRequested": false,
             "isRead": false,
             "isDraft": false,
-            "webLink": "https://example.comexample.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOwAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
+            "webLink": "https://example.com.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOwAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
             "inferenceClassification": "focused",
             "body": {
                 "contentType": "html",
@@ -370,7 +370,7 @@
             "isReadReceiptRequested": false,
             "isRead": false,
             "isDraft": false,
-            "webLink": "https://example.comexample.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOvAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
+            "webLink": "https://example.com.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOvAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
             "inferenceClassification": "focused",
             "body": {
                 "contentType": "html",
@@ -429,7 +429,7 @@
             "isReadReceiptRequested": false,
             "isRead": false,
             "isDraft": false,
-            "webLink": "https://example.comexample.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOuAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
+            "webLink": "https://example.com.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOuAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
             "inferenceClassification": "focused",
             "body": {
                 "contentType": "html",
@@ -488,7 +488,7 @@
             "isReadReceiptRequested": false,
             "isRead": false,
             "isDraft": false,
-            "webLink": "https://example.comexample.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOtAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
+            "webLink": "https://example.com.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOtAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
             "inferenceClassification": "focused",
             "body": {
                 "contentType": "html",
@@ -547,7 +547,7 @@
             "isReadReceiptRequested": false,
             "isRead": false,
             "isDraft": false,
-            "webLink": "https://example.comexample.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOsAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
+            "webLink": "https://example.com.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAEZtK4pAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE0dcOsAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
             "inferenceClassification": "focused",
             "body": {
                 "contentType": "html",

--- a/unit_test/payloads/get_messages_payload_one_basic_message.json
+++ b/unit_test/payloads/get_messages_payload_one_basic_message.json
@@ -22,7 +22,7 @@
             "isReadReceiptRequested": false,
             "isRead": false,
             "isDraft": false,
-            "webLink": "https://example.comexample.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAAAAAEKAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE4BZLGAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
+            "webLink": "https://example.com.com/owa/?ItemID=AAMkADI3Mzc1ZTg3LTIzYWEtNDNmNi1hZDQ5LTBiMjAzYzA3ZThhYwBGAAAAAAAxDvrPc8q6SqGLTJ9iB%2FSGBwC8UQDN7ObVSLWQuxHJ%2FdDTAAAAAAEKAAC8UQDN7ObVSLWQuxHJ%2FdDTAAE4BZLGAAA%3D&exvsurl=1&viewmodel=ReadMessageItem",
             "inferenceClassification": "focused",
             "body": {
                 "contentType": "text",

--- a/unit_test/payloads/hash_crash.eml
+++ b/unit_test/payloads/hash_crash.eml
@@ -994,7 +994,7 @@ Subject: [POTENTIAL PHISH] MESINC
 
 -----BEGIN REPORTER AGENT-----
 Reporter agent: Outlook|4.0.2|Microsoft Windows NT 10.0.14393.0 (x64)|Outlo=
-ok 198.162.1.11
+ok 198.162.1.1
 IP Address: 198.162.1.1
 Computer Name: example.com.com
 -----END REPORTER AGENT-----
@@ -1188,7 +1188,7 @@ X-BESS-ID: 1564602837-893001-7568-658-1
 X-BESS-VER: 2019.3_20190731.1910
 X-BESS-Apparent-Source-IP: 198.162.1.1
 X-BESS-Outbound-Spam-Score: 1.67
-X-BESS-Outbound-Spam-Report: Code version 3.2, rules version 198.162.1.1698 [=
+X-BESS-Outbound-Spam-Report: Code version 3.2, rules version 198.162.1.1 [=
 from
         example.com-example.com.example.com.com]
         Rule breakdown below
@@ -1374,7 +1374,7 @@ US &amp; Canada)<br>
 <div>
 <p><font face=3D"Cambria">-----BEGIN REPORTER AGENT-----</font> <br>
 <font face=3D"Cambria">Reporter agent: Outlook|4.0.2|Microsoft Windows NT 1=
-0.0.14393.0 (x64)|Outlook 198.162.1.11</font>
+0.0.14393.0 (x64)|Outlook 198.162.1.1</font>
 <br>
 <font face=3D"Cambria">IP Address: 198.162.1.1</font> <br>
 <font face=3D"Cambria">Computer Name: example.com.com</fon=
@@ -1447,7 +1447,7 @@ DHE_RSA_WITH_AES_256_GCM_SHA384) id</font>
 on.example.com</font>
 <br>
 <font face=3D"Cambria">&nbsp;(2a01:111:f400:7e51::201) by BL0PR0102CA0072.o=
-example.comexample.com</font>
+example.com.com</font>
 <br>
 <font face=3D"Cambria">&nbsp;(2603:10b6:208:25::49) with Microsoft SMTP Ser=
 ver (version=3DTLS1_2,</font>
@@ -1686,7 +1686,7 @@ M5PR22MB0730</font>
 <font face=3D"Cambria">X-BESS-Apparent-Source-IP: 198.162.1.1</font> <br>
 <font face=3D"Cambria">X-BESS-Outbound-Spam-Score: 1.67</font> <br>
 <font face=3D"Cambria">X-BESS-Outbound-Spam-Report: Code version 3.2, rules=
- version 198.162.1.1698 [from
+ version 198.162.1.1 [from
 </font><br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <font face=3D"Cambria">cloudscan=
 example.com-example.com.example.com.com]</font>
@@ -2806,7 +2806,7 @@ p></p>
 <td colspan=3D"3" style=3D"padding:0cm 0cm 18.75pt 0cm">
 <p class=3D"MsoNormal" style=3D"line-height:16.5pt"><span style=3D"font-siz=
 e:13.5pt;font-family:Helvetica;color:#002947">Example User (jman@exam=
-ple.com) has sent you a file:<o:p></o:p></span></p>
+example.com) has sent you a file:<o:p></o:p></span></p>
 </td>
 </tr>
 <tr>

--- a/unit_test/test_email_parser.py
+++ b/unit_test/test_email_parser.py
@@ -34,51 +34,6 @@ class TestEmailParser(TestCase):
         logging.basicConfig(level=logging.INFO)
         self.log = logging.getLogger("stuff")
 
-    def test_changes_to_indicators(self):
-        raw_email = """MIME-Version: 1.0
-Date: Thu, 23 Mar 2023 12:23:03 +0000
-Message-ID: <CALrM=d33cPGrap2LqRLzonBumj34reNSG6W6qdMGs6P3AtRr5A@mail.gmail.com>
-Subject: test-virus-total-json
-From: Adam Blakley <adam_blakley@rapid7.com>
-To: Adam Blakley <adam_blakley@rapid7.com>
-Content-Type: multipart/mixed; boundary="00000000000098fc7805f79056cd"
-
---00000000000098fc7805f79056cd
-Content-Type: multipart/alternative; boundary="00000000000098fc7605f79056cb"
-
---00000000000098fc7605f79056cb
-Content-Type: text/plain; charset="UTF-8"
-
-this is a body
-
---00000000000098fc7605f79056cb
-Content-Type: text/html; charset="UTF-8"
-
-<div dir="ltr">this is a body</div>
-
---00000000000098fc7605f79056cb--
---00000000000098fc7805f79056cd
-Content-Type: application/json; name="test-file.json"
-Content-Disposition: attachment; filename="test-file.json"
-Content-Transfer-Encoding: base64
-X-Attachment-Id: f_lfl33obl0
-Content-ID: <f_lfl33obl0>
-
-VGVzdCB2aXJ1c3RvdGFsIGZpbGU=
---00000000000098fc7805f79056cd--"""
-        email_parser = EmailParser(self.log)
-        email = email_parser.make_email_from_raw(
-            message_from_string(raw_email), TEST_MAILBOX_ID
-        )
-        self.assertEqual("9e639d2b2753aa0fca30ded2cccd9007", email.attached_files[0].indicators.md5)
-        self.assertEqual(
-            "53ea3cab3f19171d2f1012b81d50a6dd50e9e0eb", email.attached_files[0].indicators.sha1
-        )
-        self.assertEqual(
-
-            "dd2c66fd7b613cf59922118169da7c37fe87c311b3f9d4c6954ec72d7eed1b5d", email.attached_files[0].indicators.sha256
-        )
-
     def test_parse_from_raw(self):
         raw_email = read_file_to_string(GET_RAW_ATTACHMENT_PAYLOAD)
         email_parser = EmailParser(self.log)

--- a/unit_test/test_email_parser.py
+++ b/unit_test/test_email_parser.py
@@ -3,7 +3,6 @@ from unittest import TestCase
 import logging
 import os
 from email import message_from_string
-
 TEST_MAILBOX_ID = "somedude@hotmail.com"
 
 CURRENT_DIR = os.path.dirname(__file__)
@@ -32,7 +31,53 @@ def read_file_to_string(filename):
 
 class TestEmailParser(TestCase):
     def setUp(self) -> None:
+        logging.basicConfig(level=logging.INFO)
         self.log = logging.getLogger("stuff")
+
+    def test_changes_to_indicators(self):
+        raw_email = """MIME-Version: 1.0
+Date: Thu, 23 Mar 2023 12:23:03 +0000
+Message-ID: <CALrM=d33cPGrap2LqRLzonBumj34reNSG6W6qdMGs6P3AtRr5A@mail.gmail.com>
+Subject: test-virus-total-json
+From: Adam Blakley <adam_blakley@rapid7.com>
+To: Adam Blakley <adam_blakley@rapid7.com>
+Content-Type: multipart/mixed; boundary="00000000000098fc7805f79056cd"
+
+--00000000000098fc7805f79056cd
+Content-Type: multipart/alternative; boundary="00000000000098fc7605f79056cb"
+
+--00000000000098fc7605f79056cb
+Content-Type: text/plain; charset="UTF-8"
+
+this is a body
+
+--00000000000098fc7605f79056cb
+Content-Type: text/html; charset="UTF-8"
+
+<div dir="ltr">this is a body</div>
+
+--00000000000098fc7605f79056cb--
+--00000000000098fc7805f79056cd
+Content-Type: application/json; name="test-file.json"
+Content-Disposition: attachment; filename="test-file.json"
+Content-Transfer-Encoding: base64
+X-Attachment-Id: f_lfl33obl0
+Content-ID: <f_lfl33obl0>
+
+VGVzdCB2aXJ1c3RvdGFsIGZpbGU=
+--00000000000098fc7805f79056cd--"""
+        email_parser = EmailParser(self.log)
+        email = email_parser.make_email_from_raw(
+            message_from_string(raw_email), TEST_MAILBOX_ID
+        )
+        self.assertEqual("9e639d2b2753aa0fca30ded2cccd9007", email.attached_files[0].indicators.md5)
+        self.assertEqual(
+            "53ea3cab3f19171d2f1012b81d50a6dd50e9e0eb", email.attached_files[0].indicators.sha1
+        )
+        self.assertEqual(
+
+            "dd2c66fd7b613cf59922118169da7c37fe87c311b3f9d4c6954ec72d7eed1b5d", email.attached_files[0].indicators.sha256
+        )
 
     def test_parse_from_raw(self):
         raw_email = read_file_to_string(GET_RAW_ATTACHMENT_PAYLOAD)
@@ -85,14 +130,14 @@ class TestEmailParser(TestCase):
         self.assertEqual(attached_file.content_type, "image/png")
         self.assertEqual(attached_file.name, "example.com")
         self.assertEqual(
-            attached_file.indicators.md5, "539cefc749ed1d78e3c821307f7c1b0a"
+            attached_file.indicators.md5, "4e6b332381785e918147874620c9a778"
         )
         self.assertEqual(
-            attached_file.indicators.sha1, "9a95c01f15c461708733dac2b3fbe10901801582"
+            attached_file.indicators.sha1, "843feb4b836778969c6370dc0a6afba409a09f34"
         )
         self.assertEqual(
             attached_file.indicators.sha256,
-            "ac92883cdc6cda0735f9c3f968e6103f8dd93f705cc077dce70924eda523a916",
+            "a8ed7fe07252c245e2cf3ae606f3051ea14e47840b5883f6bdc1cafd88bf4871",
         )
 
     def test_parse_from_raw2(self):
@@ -160,13 +205,13 @@ class TestEmailParser(TestCase):
         expected_content = "VGhpcyBpcyBhIHRlc3QgYXR0YWNobWVudA0KDQpJdCBoYXMgc29tZSB0ZXh0IGluIGl0LiANCg0KYWFkcm9pZC5uZXQNCg=="
         self.assertEqual(attachment.content, expected_content)
         self.assertEqual(attachment.name, "test_example.com")
-        self.assertEqual(attachment.indicators.md5, "593aa3b46e3902094303b7ef1349d9ff")
+        self.assertEqual(attachment.indicators.md5, "17ee38189af19fa3c7047bdab0042cae")
         self.assertEqual(
-            attachment.indicators.sha1, "d1181c07e87d73803bf5786b37e8f03a176290a2"
+            attachment.indicators.sha1, "54df9bfd77f891c8181c1105bef9247c61d56e0a"
         )
         self.assertEqual(
             attachment.indicators.sha256,
-            "c08eb82e5383760cad3a4b4863dfb871b4c4252eba039c64a90ffc818907de27",
+            "a1485e471988b56478ca36c592638f225bb9c0f171e83148cfdd996ab099262c",
         )
 
     def test_parse_from_raw4(self):
@@ -285,14 +330,14 @@ Nothing here, just this text</div>
 
         attached_file = email.attached_files[0]
         self.assertEqual(
-            attached_file.indicators.md5, "2fca7949ad1004cefe685b81c3889e1c"
+            attached_file.indicators.md5, "7e7fbad36024562ff3e0f04b191463ad"
         )
         self.assertEqual(
-            attached_file.indicators.sha1, "b7e20bc9d4eb40adb1c4f103821bd461deab9d3f"
+            attached_file.indicators.sha1, "7e9c25b3bd8537d7dde9602633835137a2e4f1d0"
         )
         self.assertEqual(
             attached_file.indicators.sha256,
-            "8477aeb65fe7985cc82bc8f231ebfc519b8178d1050a9cee7f1b450e6c370240",
+            "f1c3e8c51308fdd82b6da7e7691f0fecf05a76cdafb014091ebe0aaab0b0cc47",
         )
 
     def test_single_recipient(self):

--- a/unit_test/test_email_parser.py
+++ b/unit_test/test_email_parser.py
@@ -31,7 +31,6 @@ def read_file_to_string(filename):
 
 class TestEmailParser(TestCase):
     def setUp(self) -> None:
-        logging.basicConfig(level=logging.INFO)
         self.log = logging.getLogger("stuff")
 
     def test_parse_from_raw(self):

--- a/unit_test/test_icon_file.py
+++ b/unit_test/test_icon_file.py
@@ -1,7 +1,6 @@
 from eml_parser.icon_file import IconFile
 from unittest import TestCase
 
-
 # This class tests icon file
 class TestIconFile(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Description
The data is base64 encoded binary data. To convert it to binary it needs to be base64 DECODED. Instead, the base64 string is being RE-ENCODED to a binary representation (in utf-8) of the base64 string.
Example:
A test file with the contents if 'Test virustotal file' should give a md5 value of '9e639d2b2753aa0fca30ded2cccd9007' - the plugin is returning '6578d9a7d429bde215913dfcd55aead6' which is the md5 has of the string 'VGVzdCB2aXJ1c3RvdGFsIGZpbGU=', which is (in-turn), the base64 encoding of 'Test virustotal file'
[PLGN-188](https://issues.corp.rapid7.com/browse/PLGN-188)

## Testing
<!-- Describe how this change was tested -->

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
