### PR TITLE
PLGN-251-Adding in a default of empty string if there is no  section in an email

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,6 @@ be on your way to contributing!
 
 ## Changelog
 
+* 2.0.1 - Adding in a default of empty string if there is no `From` section in an email
 * 2.0.0 - MD5, SHA1, and SHA256 Indicators for Base64 Content are now hashes of the decoded Base64 Content
 * 1.0.0 - Initial release

--- a/eml_parser/email_parser.py
+++ b/eml_parser/email_parser.py
@@ -51,7 +51,7 @@ class EmailParser(object):
         result = IconEmail()
         result.account = mailbox_id
         result.date_received = msg["Date"]
-        result.sender = get_emails_as_string(msg["From"])
+        result.sender = get_emails_as_string(msg.get("From", ""))
         result.subject = str(
             make_header(decode_header(msg["Subject"]))
         )  # This will decode mime words

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="python_eml_parser",
-    version="2.0.0",
+    version="2.0.1",
     description="Rapid7 InsightConnect email parser for email plugins",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Description
<!-- Describe what this change does and why it is needed. -->
<!-- Add JIRA link if applicable -->
There was an issue where some eml attachment files were not getting picked up correctly, this was due to there being no `from` section in the email an error was thown, instaed of adding it in as an empty string


https://issues.corp.rapid7.com/browse/PLGN-251

## Testing
<!-- Describe how this change was tested -->

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->

when using a test file we can see that the there value for sender will come back as none rather than an error 

![image](https://github.com/rapid7/python-eml-parser/assets/144030336/f42ee7f9-cfd2-490d-8523-361d1689a7f8)

when using an email with a from section it will still work as expected

![image](https://github.com/rapid7/python-eml-parser/assets/144030336/475b021d-1daa-4c47-8c38-e7fc52afea1d)

